### PR TITLE
Enable filetype indentation plugins in vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -25,7 +25,7 @@ Plugin 'bash-support.vim'
 " end Vundle
 call vundle#end()
 " filetype plugin indent on
-filetype plugin on
+filetype plugin indent on
 set title
 
 " environment


### PR DESCRIPTION
## Summary
- enable filetype indent plugin support in vimrc to ensure filetype-specific indentation is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d865a531f8832899dbfbd2f96f6a6c